### PR TITLE
Fix missing default export in module

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/src/lib/bills/bill-service.ts
+++ b/src/lib/bills/bill-service.ts
@@ -337,9 +337,19 @@ export class BillService {
   }
 
   async createBill(bill: CreateBillInstance): Promise<BillInstance> {
+    // Sanitize UUID fields - convert empty strings to null
+    const sanitizedBill = { ...bill };
+    
+    if (sanitizedBill.category_id === '') {
+      sanitizedBill.category_id = undefined;
+    }
+    if (sanitizedBill.template_id === '') {
+      sanitizedBill.template_id = undefined;
+    }
+
     const { data, error } = await this.supabase
       .from('bill_instances')
-      .insert(bill)
+      .insert(sanitizedBill)
       .select()
       .single();
 
@@ -354,9 +364,19 @@ export class BillService {
       throw new Error('Cannot edit historical bills');
     }
 
+    // Sanitize UUID fields - convert empty strings to null
+    const sanitizedUpdates = { ...updates };
+    
+    if (sanitizedUpdates.category_id === '') {
+      sanitizedUpdates.category_id = undefined;
+    }
+    if (sanitizedUpdates.template_id === '') {
+      sanitizedUpdates.template_id = undefined;
+    }
+
     const { data, error } = await this.supabase
       .from('bill_instances')
-      .update(updates)
+      .update(sanitizedUpdates)
       .eq('id', id)
       .select()
       .single();


### PR DESCRIPTION
Two main issues were addressed:

*   **PostCSS Configuration**: The `postcss.config.js` file was renamed to `postcss.config.mjs` and its export syntax was converted from CommonJS (`module.exports`) to ES modules (`export default`). This resolved the "Export default doesn't exist" error, aligning the configuration with Next.js's expectation for `.mjs` files.

*   **UUID Database Error**:
    *   In `src/app/dashboard/dashboard-client.tsx`, a `sanitizeUUIDs` helper was introduced within `handleBillFormSubmit`. This function converts empty string values (`""`) for `category_id`, `template_id`, and `user_id` to `null` before sending data to Supabase.
    *   In `src/lib/bills/bill-service.ts`, similar sanitization logic was added directly within the `createBill` and `updateBill` methods. Empty strings for `category_id` and `template_id` are now converted to `undefined` before database operations.
    *   These changes ensure that UUID fields, when left empty in the form, are correctly stored as `NULL` in the PostgreSQL database, preventing "invalid input syntax for type uuid" errors.